### PR TITLE
fixes deviceready on Android and WP8

### DIFF
--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -19,6 +19,22 @@ function setCordova(originalCordova) {
     cordova.define('cordova/exec', function (require, exports, module) {
         module.exports = exec;
     });
+
+    // android platform has its own specific initialization
+    // so to emulate it, we need to fake init function
+    if (cordova.platformId === 'android') {
+        exec.init = function () { 
+            cordova.require('cordova/channel').onNativeReady.fire(); 
+        };
+    }
+
+    // windows phone platform fires 'deviceready' event from native component
+    // so to emulate it we fire it in the bootstrap function (similar to ios)
+    if (cordova.platformId === 'windowsphone') {
+        cordova.require('cordova/platform').bootstrap = function () {
+            cordova.require('cordova/channel').onNativeReady.fire();
+        };
+    }
 }
 
 function getCordova() {


### PR DESCRIPTION
We should be consistent across platforms whether user must manually fire DeviceReady event or not. This patch automatically fires this event on Android and WP8 (already worked on iOS and Windows).