### PR TITLE
Fixed Android support

### DIFF
--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -20,11 +20,13 @@ function setCordova(originalCordova) {
         module.exports = exec;
     });
 
-    // android platform has its own specific initialization
-    // so to emulate it, we need to fake init function
+    // bootstrap logic on android performs several calls to native side
+    // which are not required when we do simulation; so we override
+    // bootstrap function with simple implementation so we don't need to 
+    // write proxy handlers for them ('messageChannel', 'show', etc)
     if (cordova.platformId === 'android') {
-        exec.init = function () { 
-            cordova.require('cordova/channel').onNativeReady.fire(); 
+        cordova.require('cordova/platform').bootstrap = function () {
+            cordova.require('cordova/channel').onNativeReady.fire();
         };
     }
 


### PR DESCRIPTION
Makes simulation working for Android platform.

Alternative solution here is adding a way to provide some default exec handlers for supported platforms - we currently specify a way for adding exec handler for plugins, but platform core (cordova.js) uses command bridge for some needs as well.