### PR TITLE
Minor improvement to correctly handle missing callbacks

### DIFF
--- a/src/app-host/app-host.js
+++ b/src/app-host/app-host.js
@@ -45,14 +45,18 @@ socket.on('exec-success', function (data) {
     console.log('exec-success:');
     console.log(data);
     var execCacheInfo = execCache[data.index];
-    execCacheInfo.success(data.result);
+    if (execCacheInfo.success) {
+        execCacheInfo.success(data.result);
+    }
 });
 
 socket.on('exec-failure', function (data) {
     console.log('exec-failure:');
     console.log(data);
     var execCacheInfo = execCache[data.index];
-    execCacheInfo.fail(data.error);
+    if (execCacheInfo.fail) {
+        execCacheInfo.fail(data.error);
+    }
 });
 
 socket.emit('register-app-host');


### PR DESCRIPTION
This could happen if 
* Api does not support callbacks, for example [navigator.notification.beep(times);] (https://github.com/apache/cordova-plugin-dialogs#navigatornotificationbeep)
* Api consumer didn't provide a callback (error or success) for some reason