### PR TITLE
Adds File Api simulation support

### DIFF
--- a/src/plugins/cordova-plugin-file/MyFile.js
+++ b/src/plugins/cordova-plugin-file/MyFile.js
@@ -1,0 +1,61 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * 'License'); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/**
+ * Interface to wrap the native File interface.
+ *
+ * This interface is necessary for creating zero-length (empty) files,
+ * something the Filesystem API allows you to do. Unfortunately, File's
+ * constructor cannot be called directly, making it impossible to instantiate
+ * an empty File in JS.
+ *
+ * @param {Object} opts Initial values.
+ * @constructor
+ */
+function MyFile(opts) {
+    var blob_ = new Blob();
+
+    this.size = opts.size || 0;
+    this.name = opts.name || '';
+    this.type = opts.type || '';
+    this.lastModifiedDate = opts.lastModifiedDate || null;
+    this.storagePath = opts.storagePath || '';
+
+    // Need some black magic to correct the object's size/name/type based on the
+    // blob that is saved.
+    Object.defineProperty(this, 'blob_', {
+        enumerable: true,
+        get: function() {
+            return blob_;
+        },
+        set: function(val) {
+            blob_ = val;
+            this.size = blob_.size;
+            this.name = blob_.name;
+            this.type = blob_.type;
+            this.lastModifiedDate = blob_.lastModifiedDate;
+        }.bind(this)
+    });
+}
+
+MyFile.prototype.constructor = MyFile;
+
+module.exports = MyFile;

--- a/src/plugins/cordova-plugin-file/app-host-clobbers.js
+++ b/src/plugins/cordova-plugin-file/app-host-clobbers.js
@@ -19,14 +19,26 @@
  *
  */
 
-// https://github.com/apache/cordova-plugin-media/
-
-// objects below are required for Windows platform to work correctly
-var Windows = Windows || {};
-Windows.Storage = Windows.Storage || {};
-Windows.Storage.StorageFolder = Windows.Storage.StorageFolder || {};
-Windows.Storage.StorageFile = Windows.Storage.StorageFile || {};
-
 module.exports = {
-    Windows: Windows
+    // This variable is required on Windows so that plugin works
+    Windows: {
+        Storage: {
+            StorageFolder: {
+                getFolderFromPathAsync: function () {}
+            },
+            StorageFile: {
+                getFileFromPathAsync: function () {}
+            },
+            ApplicationData: {
+                current: {
+                    localFolder: {
+                        path: ''
+                    },
+                    temporaryFolder: {
+                        path: ''
+                    }
+                }
+            }
+        }
+    }
 };

--- a/src/plugins/cordova-plugin-file/app-host-handlers.js
+++ b/src/plugins/cordova-plugin-file/app-host-handlers.js
@@ -19,30 +19,8 @@
  *
  */
 
-module.exports = {
-    // This variable is required on Windows so that plugin works
-    Windows: {
-        Storage: {
-            ApplicationData: {
-                current: {}
-            },
-            CreationCollisionOption: {
-                generateUniqueName: function () {}
-            },
-            FileIO: {},
-            Pickers: {
-                PickerLocationId: {}
-            }
-        },
-        Media: {
-            Capture: {
-                MediaStreamType: {}
-            }
-        },
-        UI: {
-            WebUI: {
-                WebUIApplication: {}
-            }
-        }
-    }
+module.exports = function (messages) {
+    var isWebkit = window.webkitRequestFileSystem && window.webkitResolveLocalFileSystemURL;
+
+    return isWebkit ? require('./app-host-webkit-handlers') : require('./app-host-non-webkit-handlers');
 };

--- a/src/plugins/cordova-plugin-file/app-host-non-webkit-handlers.js
+++ b/src/plugins/cordova-plugin-file/app-host-non-webkit-handlers.js
@@ -1,0 +1,804 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * 'License'); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+if (!window.indexedDB) {
+    throw new Error('indexedDB not supported');
+}
+
+// Since we are using browser implementation
+// of cordova-file-plugin for non-webkit browsers,
+// we should reference MyFile, because currently loaded
+// simulation platform might not be the 'browser'.
+// (browser platform uses this file in its implementation).
+var MyFile = require('./MyFile');
+
+// Since we are using browser implementation
+// of cordova-file-plugin for non-webkit browsers,
+// we should reference Indexed DB, because currently loaded
+// simulation platform might not be the 'browser'.
+// (browser platform uses this file in its implementation).
+var indexedDB = require('./indexedDB');
+
+var DIR_SEPARATOR = '/';
+var FILESYSTEM_PREFIX = 'file:///';
+
+var fileSystem = null;
+
+var pathsPrefix = {
+    // Read-only directory where the application is installed.
+    applicationDirectory: window.location.origin + '/',
+    // Where to put app-specific data files.
+    dataDirectory: 'file:///persistent/',
+    // Cached files that should survive app restarts.
+    // Apps should not rely on the OS to delete files in here.
+    cacheDirectory: 'file:///temporary/',
+    // Read-only directory where the application is installed.
+    // Android: the application space on external storage.
+    externalApplicationStorageDirectory: null,
+    // Android: Where to put app-specific data files on external storage.
+    externalDataDirectory: null,
+    // Android: the application cache on external storage.
+    externalCacheDirectory: null,
+    // Android: the external storage (SD card) root.
+    externalRootDirectory: null,
+    // iOS: Temp directory that the OS can clear at will.
+    tempDirectory: null,
+    // iOS: Holds app-specific files that should be synced (e.g. to iCloud).
+    syncedDataDirectory: null,
+    // iOS: Files private to the app, but that are meaningful to other applciations (e.g. Office files)
+    documentsDirectory: null,
+    // BlackBerry10: Files globally available to all apps
+    sharedDirectory: null
+};
+
+// We must override some functionality so that plugin can work properly,
+// for example, we cannot call 'cordova' or file-plugin related files before deviceready
+// event fired since app-host-handler's files initializes before them.
+document.addEventListener('deviceready', function () {
+    // We must override getFs function since we are using browser implementation
+    // of cordova-plugin-file so everything will work as expected.
+    window.cordova.require('cordova-plugin-file.fileSystems').getFs = function (name, callback) {
+        callback(new window.FileSystem(name, fileSystem.root));
+    };
+    // Special functionality for proper Firefox work.
+    window.FileSystem.prototype.__format__ = function(fullPath) {
+        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + encodeURI(fullPath));
+    };
+}, false);
+
+/*** Helpers ***/
+
+// When saving an entry, the fullPath should always lead with a slash and never
+// end with one (e.g. a directory). Also, resolve '.' and '..' to an absolute
+// one. This method ensures path is legit!
+function resolveToFullPath_(cwdFullPath, path) {
+    path = path || '';
+    var fullPath = path;
+    var prefix = '';
+
+    cwdFullPath = cwdFullPath || DIR_SEPARATOR;
+    if (cwdFullPath.indexOf(FILESYSTEM_PREFIX) === 0) {
+        prefix = cwdFullPath.substring(0, cwdFullPath.indexOf(DIR_SEPARATOR, FILESYSTEM_PREFIX.length));
+        cwdFullPath = cwdFullPath.substring(cwdFullPath.indexOf(DIR_SEPARATOR, FILESYSTEM_PREFIX.length));
+    }
+
+    var relativePath = path[0] !== DIR_SEPARATOR;
+    if (relativePath) {
+        fullPath = cwdFullPath;
+        if (cwdFullPath !== DIR_SEPARATOR) {
+            fullPath += DIR_SEPARATOR + path;
+        } else {
+            fullPath += path;
+        }
+    }
+
+    // Remove doubled separator substrings
+    var re = new RegExp(DIR_SEPARATOR + DIR_SEPARATOR, 'g');
+    fullPath = fullPath.replace(re, DIR_SEPARATOR);
+
+    // Adjust '..'s by removing parent directories when '..' flows in path.
+    var parts = fullPath.split(DIR_SEPARATOR);
+    for (var i = 0; i < parts.length; ++i) {
+        var part = parts[i];
+        if (part === '..') {
+            parts[i - 1] = '';
+            parts[i] = '';
+        }
+    }
+    fullPath = parts.filter(function(el) {
+        return el;
+    }).join(DIR_SEPARATOR);
+
+    // Add back in leading slash.
+    if (fullPath[0] !== DIR_SEPARATOR) {
+        fullPath = DIR_SEPARATOR + fullPath;
+    }
+
+    // Replace './' by current dir. ('./one/./two' -> one/two)
+    fullPath = fullPath.replace(/\.\//g, DIR_SEPARATOR);
+
+    // Replace '//' with '/'.
+    fullPath = fullPath.replace(/\/\//g, DIR_SEPARATOR);
+
+    // Replace '/.' with '/'.
+    fullPath = fullPath.replace(/\/\./g, DIR_SEPARATOR);
+
+    // Remove '/' if it appears on the end.
+    if (fullPath[fullPath.length - 1] === DIR_SEPARATOR &&
+        fullPath !== DIR_SEPARATOR) {
+        fullPath = fullPath.substring(0, fullPath.length - 1);
+    }
+
+    var storagePath = prefix + fullPath;
+    storagePath = decodeURI(storagePath);
+    fullPath = decodeURI(fullPath);
+
+    return {
+        storagePath: storagePath,
+        fullPath: fullPath,
+        fileName: fullPath.split(DIR_SEPARATOR).pop(),
+        fsName: prefix.split(DIR_SEPARATOR).pop()
+    };
+}
+
+function fileEntryFromIdbEntry(fileEntry) {
+    // IDB won't save methods, so we need re-create the FileEntry.
+    var clonedFileEntry = new window.FileEntry(fileEntry.name, fileEntry.fullPath, fileEntry.filesystem);
+    clonedFileEntry.file_ = fileEntry.file_;
+
+    return clonedFileEntry;
+}
+
+function readAs(what, fullPath, encoding, startPos, endPos, successCallback, errorCallback) {
+    getFile(function(fileEntry) {
+        var fileReader = new FileReader(),
+            blob = fileEntry.file_.blob_.slice(startPos, endPos);
+
+        fileReader.onload = function(e) {
+            successCallback(e.target.result);
+        };
+
+        fileReader.onerror = errorCallback;
+
+        switch (what) {
+            case 'text':
+                fileReader.readAsText(blob, encoding);
+                break;
+            case 'dataURL':
+                fileReader.readAsDataURL(blob);
+                break;
+            case 'arrayBuffer':
+                fileReader.readAsArrayBuffer(blob);
+                break;
+            case 'binaryString':
+                fileReader.readAsBinaryString(blob);
+                break;
+        }
+
+    }, errorCallback, [fullPath, null]);
+}
+
+/*** Handlers ***/
+
+function requestFileSystem(successCallback, errorCallback, args) {
+    var type = args[0];
+    // Size is ignored since IDB filesystem size depends
+    // on browser implementation and can't be set up by user
+    var size = args[1]; // jshint ignore: line
+
+    if (type !== window.LocalFileSystem.TEMPORARY && type !== window.LocalFileSystem.PERSISTENT) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    var name = type === window.LocalFileSystem.TEMPORARY ? 'temporary' : 'persistent';
+    var storageName = (location.protocol + location.host).replace(/:/g, '_');
+
+    var root = new window.DirectoryEntry('', DIR_SEPARATOR);
+    fileSystem = new window.FileSystem(name, root);
+
+    indexedDB.open(storageName, function() {
+        successCallback(fileSystem);
+    }, errorCallback);
+}
+
+function requestFileSystemHandler(successCallback, errorCallback, module, event, args) {
+    requestFileSystem(successCallback, errorCallback, args);
+}
+
+// list a directory's contents (files and folders).
+function readEntries(successCallback, errorCallback, args) {
+    var fullPath = args[0];
+
+    if (typeof successCallback !== 'function') {
+        throw Error('Expected successCallback argument.');
+    }
+
+    var path = resolveToFullPath_(fullPath);
+
+    getDirectory(function() {
+        indexedDB.getAllEntries(path.fullPath + DIR_SEPARATOR, path.storagePath, function(entries) {
+            successCallback(entries);
+        }, errorCallback);
+    }, function() {
+        if (errorCallback) {
+            errorCallback(window.FileError.NOT_FOUND_ERR);
+        }
+    }, [path.storagePath, path.fullPath, {create: false}]);
+}
+
+function readEntriesHandler(successCallback, errorCallback, module, event, args) {
+    readEntries(successCallback, errorCallback, args);
+}
+
+function getFile(successCallback, errorCallback, args) {
+    var fullPath = args[0];
+    var path = args[1];
+    var options = args[2] || {};
+
+    // Create an absolute path if we were handed a relative one.
+    path = resolveToFullPath_(fullPath, path);
+
+    indexedDB.get(path.storagePath, function(fileEntry) {
+        if (options.create === true && options.exclusive === true && fileEntry) {
+            // If create and exclusive are both true, and the path already exists,
+            // getFile must fail.
+
+            if (errorCallback) {
+                errorCallback(window.FileError.PATH_EXISTS_ERR);
+            }
+        } else if (options.create === true && !fileEntry) {
+            // If create is true, the path doesn't exist, and no other error occurs,
+            // getFile must create it as a zero-length file and return a corresponding
+            // FileEntry.
+            var newFileEntry = new window.FileEntry(path.fileName, path.fullPath, new window.FileSystem(path.fsName, fileSystem.root));
+
+            newFileEntry.file_ = new MyFile({
+                size: 0,
+                name: newFileEntry.name,
+                lastModifiedDate: new Date(),
+                storagePath: path.storagePath
+            });
+
+            indexedDB.put(newFileEntry, path.storagePath, successCallback, errorCallback);
+        } else if (options.create === true && fileEntry) {
+            if (fileEntry.isFile) {
+                // Overwrite file, delete then create new.
+                indexedDB['delete'](path.storagePath, function() {
+                    var newFileEntry = new window.FileEntry(path.fileName, path.fullPath, new window.FileSystem(path.fsName, fileSystem.root));
+
+                    newFileEntry.file_ = new MyFile({
+                        size: 0,
+                        name: newFileEntry.name,
+                        lastModifiedDate: new Date(),
+                        storagePath: path.storagePath
+                    });
+
+                    indexedDB.put(newFileEntry, path.storagePath, successCallback, errorCallback);
+                }, errorCallback);
+            } else {
+                if (errorCallback) {
+                    errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+                }
+            }
+        } else if ((!options.create || options.create === false) && !fileEntry) {
+            // If create is not true and the path doesn't exist, getFile must fail.
+            if (errorCallback) {
+                errorCallback(window.FileError.NOT_FOUND_ERR);
+            }
+        } else if ((!options.create || options.create === false) && fileEntry &&
+            fileEntry.isDirectory) {
+            // If create is not true and the path exists, but is a directory, getFile
+            // must fail.
+            if (errorCallback) {
+                errorCallback(window.FileError.TYPE_MISMATCH_ERR);
+            }
+        } else {
+            // Otherwise, if no other error occurs, getFile must return a FileEntry
+            // corresponding to path.
+
+            successCallback(fileEntryFromIdbEntry(fileEntry));
+        }
+    }, errorCallback);
+}
+
+function getFileHandler(successCallback, errorCallback, module, event, args) {
+    getFile(successCallback, errorCallback, args);
+}
+
+function getFileMetadata(successCallback, errorCallback, module, event, args) {
+    var fullPath = args[0];
+
+    getFile(function(fileEntry) {
+        successCallback(new window.File(fileEntry.file_.name, fileEntry.fullPath, '', fileEntry.file_.lastModifiedDate,
+            fileEntry.file_.size));
+    }, errorCallback, [fullPath, null]);
+}
+
+function setMetadata(successCallback, errorCallback, module, event, args) {
+    var fullPath = args[0];
+    var metadataObject = args[1];
+
+    getFile(function (fileEntry) {
+          fileEntry.file_.lastModifiedDate = metadataObject.modificationTime;
+          indexedDB.put(fileEntry, fileEntry.file_.storagePath, successCallback, errorCallback);
+    }, errorCallback, [fullPath, null]);
+}
+
+function write(successCallback, errorCallback, args) {
+    var fileName = args[0],
+        data = args[1],
+        position = args[2],
+        isBinary = args[3]; // jshint ignore: line
+
+    if (!data) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    if (typeof data === 'string' || data instanceof String) {
+        data = new Blob([data]);
+    }
+
+    getFile(function(fileEntry) {
+        var blob_ = fileEntry.file_.blob_;
+
+        if (!blob_) {
+            blob_ = new Blob([data], {type: data.type});
+        } else {
+            // Calc the head and tail fragments
+            var head = blob_.slice(0, position);
+            var tail = blob_.slice(position + (data.size || data.byteLength));
+
+            // Calc the padding
+            var padding = position - head.size;
+            if (padding < 0) {
+                padding = 0;
+            }
+
+            // Do the 'write'. In fact, a full overwrite of the Blob.
+            blob_ = new Blob([head, new Uint8Array(padding), data, tail],
+                {type: data.type});
+        }
+
+        // Set the blob we're writing on this file entry so we can recall it later.
+        fileEntry.file_.blob_ = blob_;
+        fileEntry.file_.lastModifiedDate = new Date() || null;
+        fileEntry.file_.size = blob_.size;
+        fileEntry.file_.name = blob_.name;
+        fileEntry.file_.type = blob_.type;
+
+        indexedDB.put(fileEntry, fileEntry.file_.storagePath, function() {
+            successCallback(data.size || data.byteLength);
+        }, errorCallback);
+    }, errorCallback, [fileName, null]);
+}
+
+function writeHandler(successCallback, errorCallback, module, event, args) {
+    write(successCallback, errorCallback, args);
+}
+
+function readAsTextHandler(successCallback, errorCallback, module, event, args) {
+    var fileName = args[0],
+        enc = args[1],
+        startPos = args[2],
+        endPos = args[3];
+
+    readAs('text', fileName, enc, startPos, endPos, successCallback, errorCallback);
+}
+
+function readAsDataURLHandler(successCallback, errorCallback, module, event, args) {
+    var fileName = args[0],
+        startPos = args[1],
+        endPos = args[2];
+
+    readAs('dataURL', fileName, null, startPos, endPos, successCallback, errorCallback);
+}
+
+function readAsBinaryStringHandler(successCallback, errorCallback, module, event, args) {
+    var fileName = args[0],
+        startPos = args[1],
+        endPos = args[2];
+
+    readAs('binaryString', fileName, null, startPos, endPos, successCallback, errorCallback);
+}
+
+function readAsArrayBufferHandler(successCallback, errorCallback, module, event, args) {
+    var fileName = args[0],
+        startPos = args[1],
+        endPos = args[2];
+
+    readAs('arrayBuffer', fileName, null, startPos, endPos, successCallback, errorCallback);
+}
+
+function removeRecursively(successCallback, errorCallback, module, event, args) {
+    removeHandler(successCallback, errorCallback, module, event, args);
+}
+
+function remove(successCallback, errorCallback, args) {
+    var fullPath = resolveToFullPath_(args[0]).storagePath;
+    if (fullPath === pathsPrefix.cacheDirectory || fullPath === pathsPrefix.dataDirectory) {
+        errorCallback(window.FileError.NO_MODIFICATION_ALLOWED_ERR);
+        return;
+    }
+
+    function deleteEntry(isDirectory) {
+        // TODO: This doesn't protect against directories that have content in it.
+        // Should throw an error instead if the dirEntry is not empty.
+        indexedDB['delete'](fullPath, function() {
+            successCallback && successCallback();
+        }, function() {
+                errorCallback && errorCallback();
+        }, isDirectory);
+    }
+
+    // We need to to understand what we are deleting:
+    getDirectory(function(entry) {
+        deleteEntry(entry.isDirectory);
+    }, function(){
+        //DirectoryEntry was already deleted or entry is FileEntry
+        deleteEntry(false);
+    }, [fullPath, null, {create: false}]);
+}
+
+function removeHandler(successCallback, errorCallback, module, event, args) {
+    remove(successCallback, errorCallback, args);
+}
+
+function getDirectory(successCallback, errorCallback, args) {
+    var fullPath = args[0];
+    var path = args[1];
+    var options = args[2];
+
+    // Create an absolute path if we were handed a relative one.
+    path = resolveToFullPath_(fullPath, path);
+
+    indexedDB.get(path.storagePath, function(folderEntry) {
+        if (!options) {
+            options = {};
+        }
+
+        if (options.create === true && options.exclusive === true && folderEntry) {
+            // If create and exclusive are both true, and the path already exists,
+            // getDirectory must fail.
+            if (errorCallback) {
+                errorCallback(window.FileError.PATH_EXISTS_ERR);
+            }
+            // There is a strange bug in mobilespec + FF, which results in coming to multiple else-if's
+            // so we are shielding from it with returns.
+            return;
+        }
+
+        if (options.create === true && !folderEntry) {
+            // If create is true, the path doesn't exist, and no other error occurs,
+            // getDirectory must create it as a zero-length file and return a corresponding
+            // MyDirectoryEntry.
+            var dirEntry = new window.DirectoryEntry(path.fileName, path.fullPath, new window.FileSystem(path.fsName, fileSystem.root));
+
+            indexedDB.put(dirEntry, path.storagePath, successCallback, errorCallback);
+            return;
+        }
+
+        if (options.create === true && folderEntry) {
+
+            if (folderEntry.isDirectory) {
+                // IDB won't save methods, so we need re-create the MyDirectoryEntry.
+                successCallback(new window.DirectoryEntry(folderEntry.name, folderEntry.fullPath, folderEntry.filesystem));
+            } else {
+                if (errorCallback) {
+                    errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+                }
+            }
+            return;
+        }
+
+        if ((!options.create || options.create === false) && !folderEntry) {
+            // Handle root special. It should always exist.
+            if (path.fullPath === DIR_SEPARATOR) {
+                successCallback(fileSystem.root);
+                return;
+            }
+
+            // If create is not true and the path doesn't exist, getDirectory must fail.
+            if (errorCallback) {
+                errorCallback(window.FileError.NOT_FOUND_ERR);
+            }
+
+            return;
+        }
+        if ((!options.create || options.create === false) && folderEntry && folderEntry.isFile) {
+            // If create is not true and the path exists, but is a file, getDirectory
+            // must fail.
+            if (errorCallback) {
+                errorCallback(window.FileError.TYPE_MISMATCH_ERR);
+            }
+            return;
+        }
+
+        // Otherwise, if no other error occurs, getDirectory must return a
+        // MyDirectoryEntry corresponding to path.
+
+        // IDB won't' save methods, so we need re-create MyDirectoryEntry.
+        successCallback(new window.DirectoryEntry(folderEntry.name, folderEntry.fullPath, folderEntry.filesystem));
+    }, errorCallback);
+}
+
+function getDirectoryHandler(successCallback, errorCallback, module, event, args) {
+    getDirectory(successCallback, errorCallback, args);
+}
+
+function getParentHandler(successCallback, errorCallback, module, args) {
+    if (typeof successCallback !== 'function') {
+        throw Error('Expected successCallback argument.');
+    }
+
+    var fullPath = args[0];
+    //fullPath is like this:
+    //file:///persistent/path/to/file or
+    //file:///persistent/path/to/directory/
+
+    if (fullPath === DIR_SEPARATOR || fullPath === pathsPrefix.cacheDirectory ||
+        fullPath === pathsPrefix.dataDirectory) {
+        successCallback(fileSystem.root);
+        return;
+    }
+
+    //To delete all slashes at the end
+    while (fullPath[fullPath.length - 1] === '/') {
+        fullPath = fullPath.substr(0, fullPath.length - 1);
+    }
+
+    var pathArr = fullPath.split(DIR_SEPARATOR);
+    pathArr.pop();
+    var parentName = pathArr.pop();
+    var path = pathArr.join(DIR_SEPARATOR) + DIR_SEPARATOR;
+
+    //To get parent of root files
+    var joined = path + parentName + DIR_SEPARATOR;//is like this: file:///persistent/
+    if (joined === pathsPrefix.cacheDirectory || joined === pathsPrefix.dataDirectory) {
+        getDirectory(successCallback, errorCallback, [joined, DIR_SEPARATOR, {create: false}]);
+        return;
+    }
+
+    getDirectory(successCallback, errorCallback, [path, parentName, {create: false}]);
+}
+
+function copyTo(successCallback, errorCallback, args) {
+    var srcPath = args[0];
+    var parentFullPath = args[1];
+    var name = args[2];
+
+    if (name.indexOf('/') !== -1 || srcPath === parentFullPath + name) {
+        if (errorCallback) {
+            errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        }
+
+        return;
+    }
+
+    // Read src file
+    getFile(function(srcFileEntry) {
+
+        var path = resolveToFullPath_(parentFullPath);
+        //Check directory
+        getDirectory(function() {
+
+            // Create dest file
+            getFile(function(dstFileEntry) {
+
+                write(function() {
+                    successCallback(dstFileEntry);
+                }, errorCallback, [dstFileEntry.file_.storagePath, srcFileEntry.file_.blob_, 0]);
+
+            }, errorCallback, [parentFullPath, name, {create: true}]);
+
+        }, function() { if (errorCallback) { errorCallback(window.FileError.NOT_FOUND_ERR); }},
+        [path.storagePath, null, {create:false}]);
+
+    }, errorCallback, [srcPath, null]);
+}
+
+function copyToHandler(successCallback, errorCallback, module, event, args) {
+    copyTo(successCallback, errorCallback, args);
+}
+
+function moveToHandler(successCallback, errorCallback, module, event, args) {
+    var srcPath = args[0];
+    // parentFullPath and name parameters is ignored because
+    // args is being passed downstream to exports.copyTo method
+    var parentFullPath = args[1]; // jshint ignore: line
+    var name = args[2]; // jshint ignore: line
+
+    copyTo(function (fileEntry) {
+        remove(function () {
+            successCallback(fileEntry);
+        }, errorCallback, [srcPath]);
+    }, errorCallback, args);
+}
+
+function resolveLocalFileSystemURI(successCallback, errorCallback, args) {
+    var path = args[0];
+
+    // Ignore parameters
+    if (path.indexOf('?') !== -1) {
+        path = String(path).split('?')[0];
+    }
+
+    // support for encodeURI
+    if (/\%5/g.test(path) || /\%20/g.test(path)) {
+        path = decodeURI(path);
+    }
+
+    if (path.trim()[0] === '/') {
+        errorCallback && errorCallback(window.FileError.ENCODING_ERR);
+        return;
+    }
+
+    //support for cdvfile
+    if (path.trim().substr(0,7) === 'cdvfile') {
+        if (path.indexOf('cdvfile://localhost') === -1) {
+            errorCallback && errorCallback(window.FileError.ENCODING_ERR);
+            return;
+        }
+
+        var indexPersistent = path.indexOf('persistent');
+        var indexTemporary = path.indexOf('temporary');
+
+        //cdvfile://localhost/persistent/path/to/file
+        if (indexPersistent !== -1) {
+            path =  'file:///persistent' + path.substr(indexPersistent + 10);
+        } else if (indexTemporary !== -1) {
+            path = 'file:///temporary' + path.substr(indexTemporary + 9);
+        } else {
+            errorCallback && errorCallback(window.FileError.ENCODING_ERR);
+            return;
+        }
+    }
+
+    // to avoid path form of '///path/to/file'
+    function handlePathSlashes(path) {
+        var cutIndex  = 0;
+        for (var i = 0; i < path.length - 1; i++) {
+            if (path[i] === DIR_SEPARATOR && path[i + 1] === DIR_SEPARATOR) {
+                cutIndex = i + 1;
+            } else break;
+        }
+
+        return path.substr(cutIndex);
+    }
+
+    // Handle localhost containing paths (see specs )
+    if (path.indexOf('file://localhost/') === 0) {
+        path = path.replace('file://localhost/', 'file:///');
+    }
+
+    if (path.indexOf(pathsPrefix.dataDirectory) === 0) {
+        path = path.substring(pathsPrefix.dataDirectory.length - 1);
+        path = handlePathSlashes(path);
+
+        requestFileSystem(function() {
+            getFile(successCallback, function() {
+                getDirectory(successCallback, errorCallback, [pathsPrefix.dataDirectory, path,
+                {create: false}]);
+            }, [pathsPrefix.dataDirectory, path, {create: false}]);
+        }, errorCallback, [window.LocalFileSystem.PERSISTENT]);
+    } else if (path.indexOf(pathsPrefix.cacheDirectory) === 0) {
+        path = path.substring(pathsPrefix.cacheDirectory.length - 1);
+        path = handlePathSlashes(path);
+
+        requestFileSystem(function() {
+            getFile(successCallback, function() {
+                getDirectory(successCallback, errorCallback, [pathsPrefix.cacheDirectory, path,
+                {create: false}]);
+            }, [pathsPrefix.cacheDirectory, path, {create: false}]);
+        }, errorCallback, [window.LocalFileSystem.TEMPORARY]);
+    } else if (path.indexOf(pathsPrefix.applicationDirectory) === 0) {
+        path = path.substring(pathsPrefix.applicationDirectory.length);
+        //TODO: need to cut out redundant slashes?
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', path, true);
+        xhr.onreadystatechange = function () {
+            if (xhr.status === 200 && xhr.readyState === 4) {
+                requestFileSystem(function(fs) {
+                    fs.name = location.hostname;
+
+                    //TODO: need to call exports.getFile(...) to handle errors correct
+                    fs.root.getFile(path, {create: true}, writeFile, errorCallback);
+                }, errorCallback, [window.LocalFileSystem.PERSISTENT]);
+            }
+        };
+
+        xhr.onerror = function () {
+            errorCallback && errorCallback(window.FileError.NOT_READABLE_ERR);
+        };
+
+        xhr.send();
+    } else {
+        errorCallback && errorCallback(window.FileError.NOT_FOUND_ERR);
+    }
+
+    function writeFile(entry) {
+        entry.createWriter(function (fileWriter) {
+            fileWriter.onwriteend = function (evt) {
+                if (!evt.target.error) {
+                    entry.filesystemName = location.hostname;
+                    successCallback(entry);
+                }
+            };
+            fileWriter.onerror = function () {
+                errorCallback && errorCallback(window.FileError.NOT_READABLE_ERR);
+            };
+            fileWriter.write(new Blob([xhr.response]));
+        }, errorCallback);
+    }
+}
+
+function resolveLocalFileSystemURIHandler(successCallback, errorCallback, module, event, args) {
+    resolveLocalFileSystemURI(successCallback, errorCallback, args);
+}
+
+function requestAllPathsHandler(successCallback, errorCallback, module, event, args) {
+    successCallback(pathsPrefix);
+}
+
+// This handler is required for tests and backwards compatibility
+function _getLocalFilesystemPathHandler(successCallback, errorCallback, module, event, args) {
+    var url = args[0];
+    var stringToCut = 'file://';
+    var fileIndex = url.indexOf(stringToCut);
+    if (fileIndex !== -1) {
+        url = url.substr(stringToCut.length, url.length-stringToCut.length);
+    }
+    successCallback(url);
+}
+
+function notifyNotSupported(success, fail, args) {
+    fail('This method is not supported yet');
+}
+
+module.exports = {
+    'File': {
+        'requestAllPaths': requestAllPathsHandler,
+        'getDirectory': getDirectoryHandler,
+        'removeRecursively': removeRecursively,
+        'getFile': getFileHandler,
+        'readEntries': readEntriesHandler,
+        'getFileMetadata': getFileMetadata,
+        'setMetadata': setMetadata,
+        'moveTo': moveToHandler,
+        'copyTo': copyToHandler,
+        'remove': removeHandler,
+        'getParent': getParentHandler,
+        'readAsDataURL': readAsDataURLHandler,
+        'readAsBinaryString': readAsBinaryStringHandler,
+        'readAsArrayBuffer': readAsArrayBufferHandler,
+        'readAsText': readAsTextHandler,
+        'write': writeHandler,
+        'requestFileSystem': requestFileSystemHandler,
+        'resolveLocalFileSystemURI': resolveLocalFileSystemURIHandler,
+        // exec's below are not implemented in browser platform
+        'truncate': notifyNotSupported,
+        'requestAllFileSystems': notifyNotSupported,
+        // method below is used for backward compatibility w/ old File plugin implementation
+        '_getLocalFilesystemPath': _getLocalFilesystemPathHandler
+    }
+};

--- a/src/plugins/cordova-plugin-file/app-host-webkit-handlers.js
+++ b/src/plugins/cordova-plugin-file/app-host-webkit-handlers.js
@@ -1,0 +1,205 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * 'License'); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var filePluginIsReadyEvent = new Event('filePluginIsReady');
+var PERSISTENT_FS_QUOTA = 5 * 1024 * 1024;
+
+var entryFunctionsCreated = false;
+var quotaWasRequested = false;
+var eventWasThrown = false;
+
+window.initPersistentFileSystem = function(size, win, fail) {
+    if (navigator.webkitPersistentStorage) {
+        navigator.webkitPersistentStorage.requestQuota(size, win, fail);
+        return;
+    }
+
+    fail('This browser does not support this function');
+};
+
+window.isFilePluginReadyRaised = function () { return eventWasThrown; };
+
+window.initPersistentFileSystem(PERSISTENT_FS_QUOTA, function() {
+    console.log('Persistent fs quota granted');
+    quotaWasRequested = true;
+}, function(e){
+    console.log('Error occured while trying to request Persistent fs quota: ' + JSON.stringify(e));
+});
+
+function dispatchEventIfReady() {
+    if (entryFunctionsCreated && quotaWasRequested) {
+        window.dispatchEvent(filePluginIsReadyEvent);
+        eventWasThrown = true;
+    } else {
+        setTimeout(dispatchEventIfReady, 100);
+    }
+}
+
+// We create and fire event 'filePluginIsReady' when file system persistent file quota
+// is granted and entry functions are overriden, so we can already work with file system properly.
+dispatchEventIfReady();
+
+// We must override some functionality so that plugin can work properly,
+// for example, if we override window.requestFileSystem or window.resolveLocalFileSystemURL,
+// they might be overrided later, and if we will wait for deviceready event, we assume that
+// these functions will not be overrided later.
+document.addEventListener('deviceready', function () {
+    window.requestFileSystem = window.webkitRequestFileSystem;
+
+    if (!window.requestFileSystem) {
+        window.requestFileSystem = function(type, size, win, fail) {
+            if (fail) {
+                fail('Not supported');
+            }
+        };
+    } else {
+        window.requestFileSystem(window.TEMPORARY, 1, createFileEntryFunctions, function() {});
+    }
+
+    function createFileEntryFunctions(fs) {
+        fs.root.getFile('todelete_658674_833_4_cdv', {create: true}, function(fileEntry) {
+            var fileEntryType = Object.getPrototypeOf(fileEntry);
+            var entryType = Object.getPrototypeOf(fileEntryType);
+
+            // Save the original method
+            var origToURL = entryType.toURL;
+            entryType.toURL = function () {
+                var origURL = origToURL.call(this);
+                if (this.isDirectory && origURL.substr(-1) !== '/') {
+                    return origURL + '/';
+                }
+                return origURL;
+            };
+
+            entryType.toNativeURL = function () {
+                console.warn('DEPRECATED: Update your code to use \'toURL\'');
+                return this.toURL();
+            };
+
+            entryType.toInternalURL = function() {
+                if (this.toURL().indexOf('persistent') > -1) {
+                    return 'cdvfile://localhost/persistent' + this.fullPath;
+                }
+
+                if (this.toURL().indexOf('temporary') > -1) {
+                    return 'cdvfile://localhost/temporary' + this.fullPath;
+                }
+            };
+
+            entryType.setMetadata = function(win, fail /*, metadata*/) {
+                fail && fail('Not supported');
+            };
+
+            fileEntry.createWriter(function(writer) {
+                var originalWrite = writer.write;
+                var writerProto = Object.getPrototypeOf(writer);
+                writerProto.write = function(blob) {
+                    if(blob instanceof Blob) {
+                        originalWrite.apply(this, [blob]);
+                    } else {
+                        var realBlob = new Blob([blob]);
+                        originalWrite.apply(this, [realBlob]);
+                   }
+                };
+
+                fileEntry.remove(function(){ entryFunctionsCreated = true; }, function(){ /* empty callback */ });
+          });
+        });
+    }
+
+    if (!window.resolveLocalFileSystemURL) {
+        window.resolveLocalFileSystemURL = function(url, win, fail) {
+            if(fail) {
+                fail('Not supported');
+            }
+        };
+    }
+
+    // Resolves a filesystem entry by its path - which is passed either in standard (filesystem:file://) or
+    // Cordova-specific (cdvfile://) universal way.
+    // Aligns with specification: http://www.w3.org/TR/2011/WD-file-system-api-20110419/#widl-LocalFileSystem-resolveLocalFileSystemURL
+    var nativeResolveLocalFileSystemURL = window.webkitResolveLocalFileSystemURL || window.resolveLocalFileSystemURL;
+    window.resolveLocalFileSystemURL = function(url, win, fail) {
+        /* If url starts with `cdvfile` then we need convert it to Chrome real url first:
+          cdvfile://localhost/persistent/path/to/file -> filesystem:file://persistent/path/to/file */
+        if (url.trim().substr(0,7) === 'cdvfile') {
+            /* Quirk:
+            Plugin supports cdvfile://localhost (local resources) only.
+            I.e. external resources are not supported via cdvfile. */
+            if (url.indexOf('cdvfile://localhost') !== -1) {
+                // Browser supports temporary and persistent only
+                var indexPersistent = url.indexOf('persistent');
+                var indexTemporary = url.indexOf('temporary');
+
+                /* Chrome urls start with 'filesystem:' prefix. See quirk:
+                   toURL function in Chrome returns filesystem:-prefixed path depending on application host.
+                   For example, filesystem:file:///persistent/somefile.txt,
+                   filesystem:http://localhost:8080/persistent/somefile.txt. */
+                var prefix = 'filesystem:file:///';
+                if (location.protocol !== 'file:') {
+                    prefix = 'filesystem:' + location.origin + '/';
+                }
+
+                var result;
+                if (indexPersistent !== -1) {
+                    // cdvfile://localhost/persistent/path/to/file -> filesystem:file://persistent/path/to/file
+                    // or filesystem:http://localhost:8080/persistent/path/to/file
+                    result =  prefix + 'persistent' + url.substr(indexPersistent + 10);
+                    nativeResolveLocalFileSystemURL(result, win, fail);
+                    return;
+                }
+
+                if (indexTemporary !== -1) {
+                    // cdvfile://localhost/temporary/path/to/file -> filesystem:file://temporary/path/to/file
+                    // or filesystem:http://localhost:8080/temporary/path/to/file
+                    result = prefix + 'temporary' + url.substr(indexTemporary + 9);
+                    nativeResolveLocalFileSystemURL(result, win, fail);
+                    return;
+                }
+            }
+
+            // cdvfile other than local file resource is not supported
+            fail && fail(function () {throw new window.FileError(window.FileError.ENCODING_ERR);});
+        } else if (url.trim().indexOf('file://') === 0) {
+            // ADDED
+            url = 'filesystem:http://' + url.replace('file://', '');
+            nativeResolveLocalFileSystemURL(url, win, fail);
+        } else {
+            nativeResolveLocalFileSystemURL(url, win, fail);
+        }
+    };
+}, false);
+
+// This handler is required for tests and backwards compatibility
+function _getLocalFilesystemPathHandler(successCallback, errorCallback, module, event, args) {
+    var url = args[0];
+    var localhostIndex = url.indexOf('localhost');
+    if (localhostIndex !== -1) {
+        url = url.substr(localhostIndex, url.length-localhostIndex);
+    }
+    successCallback(url);
+}
+
+module.exports = {
+    'File': {
+        '_getLocalFilesystemPath': _getLocalFilesystemPathHandler
+    }
+};

--- a/src/plugins/cordova-plugin-file/indexedDB.js
+++ b/src/plugins/cordova-plugin-file/indexedDB.js
@@ -1,0 +1,210 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * 'License'); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+var indexedDB = {
+    db: null
+};
+
+var FILE_STORE_ = 'entries',
+    DIR_SEPARATOR = '/',
+    unicodeLastChar = 65535;
+
+indexedDB.open = function(dbName, successCallback, errorCallback) {
+    var self = this;
+
+    // TODO: FF 12.0a1 isn't liking a db name with : in it.
+    var request = window.indexedDB.open(dbName.replace(':', '_')/*, 1 /*version*/);
+
+    request.onerror = errorCallback || onError;
+
+    request.onupgradeneeded = function(e) {
+        // First open was called or higher db version was used.
+
+        // console.log('onupgradeneeded: oldVersion:' + e.oldVersion,
+        //           'newVersion:' + e.newVersion);
+
+        self.db = e.target.result;
+        self.db.onerror = onError;
+
+        if (!self.db.objectStoreNames.contains(FILE_STORE_)) {
+            self.db.createObjectStore(FILE_STORE_/*,{keyPath: 'id', autoIncrement: true}*/);
+        }
+    };
+
+    request.onsuccess = function(e) {
+        self.db = e.target.result;
+        self.db.onerror = onError;
+        successCallback(e);
+    };
+
+    request.onblocked = errorCallback || onError;
+};
+
+indexedDB.close = function() {
+    this.db.close();
+    this.db = null;
+};
+
+indexedDB.get = function(fullPath, successCallback, errorCallback) {
+    if (!this.db) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    var tx = this.db.transaction([FILE_STORE_], 'readonly');
+
+    var request = tx.objectStore(FILE_STORE_).get(fullPath);
+
+    tx.onabort = errorCallback || onError;
+    tx.oncomplete = function() {
+        successCallback(request.result);
+    };
+};
+
+indexedDB.getAllEntries = function(fullPath, storagePath, successCallback, errorCallback) {
+    if (!this.db) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    var results = [];
+
+    if (storagePath[storagePath.length - 1] === DIR_SEPARATOR) {
+        storagePath = storagePath.substring(0, storagePath.length - 1);
+    }
+
+    var range = window.IDBKeyRange.bound(storagePath + DIR_SEPARATOR + ' ',
+        storagePath + DIR_SEPARATOR + String.fromCharCode(unicodeLastChar));
+
+    var tx = this.db.transaction([FILE_STORE_], 'readonly');
+    tx.onabort = errorCallback || onError;
+    tx.oncomplete = function() {
+        results = results.filter(function(val) {
+            var pathWithoutSlash = val.fullPath;
+
+            if (val.fullPath[val.fullPath.length - 1] === DIR_SEPARATOR) {
+                pathWithoutSlash = pathWithoutSlash.substr(0, pathWithoutSlash.length - 1);
+            }
+
+            var valPartsLen = pathWithoutSlash.split(DIR_SEPARATOR).length;
+            var fullPathPartsLen = fullPath.split(DIR_SEPARATOR).length;
+
+            /* Input fullPath parameter  equals '//' for root folder */
+            /* Entries in root folder has valPartsLen equals 2 (see below) */
+            if (fullPath[fullPath.length -1] === DIR_SEPARATOR && fullPath.trim().length === 2) {
+                fullPathPartsLen = 1;
+            } else if (fullPath[fullPath.length -1] === DIR_SEPARATOR) {
+                fullPathPartsLen = fullPath.substr(0, fullPath.length - 1).split(DIR_SEPARATOR).length;
+            } else {
+                fullPathPartsLen = fullPath.split(DIR_SEPARATOR).length;
+            }
+
+            if (valPartsLen === fullPathPartsLen + 1) {
+                // If this a subfolder and entry is a direct child, include it in
+                // the results. Otherwise, it's not an entry of this folder.
+                return val;
+            } else return false;
+        });
+
+        successCallback(results);
+    };
+
+    var request = tx.objectStore(FILE_STORE_).openCursor(range);
+
+    request.onsuccess = function(e) {
+        var cursor = e.target.result;
+        if (cursor) {
+            var val = cursor.value;
+
+            results.push(val.isFile ? fileEntryFromIdbEntry(val) : new window.DirectoryEntry(val.name, val.fullPath, val.filesystem));
+            cursor['continue']();
+        }
+    };
+};
+
+indexedDB['delete'] = function(fullPath, successCallback, errorCallback, isDirectory) {
+    if (!indexedDB.db) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    var tx = this.db.transaction([FILE_STORE_], 'readwrite');
+    tx.oncomplete = successCallback;
+    tx.onabort = errorCallback || onError;
+    tx.oncomplete = function() {
+        if (isDirectory) {
+            //We delete nested files and folders after deleting parent folder
+            //We use ranges: https://developer.mozilla.org/en-US/docs/Web/API/IDBKeyRange
+            fullPath = fullPath + DIR_SEPARATOR;
+
+            //Range contains all entries in the form fullPath<symbol> where
+            //symbol in the range from ' ' to symbol which has code `unicodeLastChar`
+            var range = window.IDBKeyRange.bound(fullPath + ' ', fullPath + String.fromCharCode(unicodeLastChar));
+
+            var newTx = this.db.transaction([FILE_STORE_], 'readwrite');
+            newTx.oncomplete = successCallback;
+            newTx.onabort = errorCallback || onError;
+            newTx.objectStore(FILE_STORE_)['delete'](range);
+        } else {
+            successCallback();
+        }
+    };
+    tx.objectStore(FILE_STORE_)['delete'](fullPath);
+};
+
+indexedDB.put = function(entry, storagePath, successCallback, errorCallback) {
+    if (!this.db) {
+        errorCallback && errorCallback(window.FileError.INVALID_MODIFICATION_ERR);
+        return;
+    }
+
+    var tx = this.db.transaction([FILE_STORE_], 'readwrite');
+    tx.onabort = onError;
+    tx.oncomplete = function() {
+        // TODO: Error is thrown if we pass the request event back instead.
+        successCallback(entry);
+    };
+
+    tx.objectStore(FILE_STORE_).put(entry, storagePath);
+};
+
+function onError(e) {
+    switch (e.target.errorCode) {
+        case 12:
+            console.log('Error - Attempt to open db with a lower version than the ' +
+                'current one.');
+            break;
+        default:
+            console.log('errorCode: ' + e.target.errorCode);
+    }
+
+    console.log(e, e.code, e.message);
+}
+
+function fileEntryFromIdbEntry(fileEntry) {
+    // IDB won't save methods, so we need re-create the FileEntry.
+    var clonedFileEntry = new window.FileEntry(fileEntry.name, fileEntry.fullPath, fileEntry.filesystem);
+    clonedFileEntry.file_ = fileEntry.file_;
+
+    return clonedFileEntry;
+}
+
+module.exports = indexedDB;


### PR DESCRIPTION
Based on browser implementation so have the same level of support and limitations:
* Webkit browsers: developer should wait for `filePluginIsReady` is fired before using File Api
* Non-webkit: `truncate` and `requestAllFileSystems` methods are not supported
